### PR TITLE
StreamProcessor.onComplete() does not discard accumulated messages

### DIFF
--- a/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamProcessor.java
+++ b/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamProcessor.java
@@ -200,7 +200,8 @@ public class StreamProcessor<T,R> extends Actor implements Processor<T,R>, Contr
     void termiante() {
       terminated = true;
 
-      values.clear();
+      // Terminate stops accumulating new values. Already accumulated values can be still consumed by {@link #nextValues()}.
+      // values.clear();
     }
 
     private R[] nextValues() {


### PR DESCRIPTION
From doc: 'onComplete signal when no more elements are available'.
It means that accumulated messages are not discarded by Processor.

Fixed following reactive-streams TCK tests (10):
required_createPublisher1MustProduceAStreamOfExactly1Element
required_createPublisher3MustProduceAStreamOfExactly3Elements
required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements
required_spec102_maySignalLessThanRequestedAndTerminateSubscription
required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates
required_spec107_mustNotEmitFurtherSignalsOnceOnCompleteHasBeenSignalled
required_spec312_cancelMustMakeThePublisherToEventuallyStopSignaling
required_spec313_cancelMustMakeThePublisherEventuallyDropAllReferencesToTheSubscriber
required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue
required_spec317_mustSupportAPendingElementCountUpToLongMaxValue