### PR TITLE
Fixed three reactive-streams tests for Processor

### DIFF
--- a/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamProcessor.java
+++ b/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamProcessor.java
@@ -118,6 +118,7 @@ public class StreamProcessor<T,R> extends Actor implements Processor<T,R>, Contr
 
   @Override
   public void cancel(final SubscriptionController<R> controller) {
+    subscriberDelegate.cancelSubscription();
     publisherDelegate.cancel(controller);
   }
 

--- a/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamSubscriberDelegate.java
+++ b/vlingo-streams-core/src/main/java/io/vlingo/reactivestreams/StreamSubscriberDelegate.java
@@ -74,6 +74,10 @@ public class StreamSubscriberDelegate<T> implements Subscriber<T> {
     return completed || errored;
   }
 
+  public void cancelSubscription() {
+    subscription.cancel();
+  }
+
   private void terminate() {
     sink.terminate();
   }

--- a/vlingo-streams-tck/src/test/java/io/vlingo/reactivestreams/StreamProcessorCompatibilityTest.java
+++ b/vlingo-streams-tck/src/test/java/io/vlingo/reactivestreams/StreamProcessorCompatibilityTest.java
@@ -55,6 +55,12 @@ public class StreamProcessorCompatibilityTest extends IdentityProcessorVerificat
     return new Publisher<Integer>() {
       @Override
       public void subscribe(Subscriber<? super Integer> s) {
+        // Baffling. This proves nothing about the actual publisher, and shouldn't,
+        // because designing the publisher with some sort of built-in failure
+        // condition would be even more ridiculous than this. And BTW, the
+        // subscriber will always be registered before onError() because there
+        // is no way to signal a subscriber unless it is registered.
+        s.onSubscribe(new SubscriptionController<>(s, null, null));
         s.onError(new RuntimeException("Can't subscribe subscriber: " + s + ", because of reasons."));
       }
     };


### PR DESCRIPTION
- optional_spec104_mustSignalOnErrorWhenFails
- required_exerciseWhiteboxHappyPath
- required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel